### PR TITLE
Allowing transformation of new instances of the same statement

### DIFF
--- a/DSL.Reqnroll.IntegrationTest/DSL.ReqnrollPlugin.IntegrationTests.csproj
+++ b/DSL.Reqnroll.IntegrationTest/DSL.ReqnrollPlugin.IntegrationTests.csproj
@@ -16,10 +16,6 @@
       Link="EnvironmentVariableExamples.feature.cs"
     />
     <Compile
-      Include="..\DSL.ReqnrollPlugin.Examples\Features\FunctionExamples.feature.cs"
-      Link="FunctionExamples.feature.cs"
-    />
-    <Compile
       Include="..\DSL.ReqnrollPlugin.Examples\Features\UserVariableExamples.feature.cs"
       Link="UserVariableExamples.feature.cs"
     />

--- a/DSL.ReqnrollPlugin.Examples/Features/FunctionExamples.feature
+++ b/DSL.ReqnrollPlugin.Examples/Features/FunctionExamples.feature
@@ -10,8 +10,20 @@ Scenario: I use TODAY to define formatted date/time with hour offset in local ti
 	Then verify string "{{L#TODAY-3H#dd-MM-yyyy HH:mm:ss}}" equals to today in local time 3 hours ago in format of dd-MM-yyyy HH:mm:ss
 
 Scenario: I use TODAY function without parameters as a variable
-	When entered string "[[TODAY={{TODAY}}]]"
-	Then verify string "[[TODAY]]" equals "{{TODAY}}"
+	When entered string "[[DZIS={{TODAY#dd-MM-yyyy}}]]"
+	Then verify string "[[DZIS]]" equals "{{TODAY#dd-MM-yyyy}}"
+	And verify string "[[DZIS]]" equals "{{TODAY#dd-MM-yyyy}}"
+	And verify string "[[DZIS]]" equals "{{TODAY#dd-MM-yyyy}}"
+
+Scenario: I use TODAY function and TODAY as variable in the table
+	When use table with the following details: 
+	 | Field     | Value                            |
+	 | Field 1   | [[DZIS={{TODAY#dd-MM-yyyy}}]]    |
+	Then verify column values are equal for each row:
+	 | Column A  | Column B                |
+	 | [[DZIS]]  | {{TODAY#dd-MM-yyyy}}    |
+	 | [[DZIS]]  | {{TODAY#dd-MM-yyyy}}    |
+	 | [[DZIS]]  | {{TODAY#dd-MM-yyyy}}    |
 
 Scenario: I use RANDOM function without parameters as a variable
 	When entered string "[[RVAL={{RANDOM}}]]"

--- a/DSL.ReqnrollPlugin.Examples/Steps/ExamplesStepDefinitions.cs
+++ b/DSL.ReqnrollPlugin.Examples/Steps/ExamplesStepDefinitions.cs
@@ -208,5 +208,20 @@ namespace Examples.Steps
                 }
             }
         }
+
+        [Then(@"verify column values are equal for each row:")]
+        public void ThenVerifyColumnValuesAreEqualForEachRow(Table table)
+        {
+            foreach (var row in table.Rows)
+            {
+                string? variableFromColumnA = row?[0]?.ToString();
+                string? variableFromColumnB = row?[1]?.ToString();
+
+                if (!string.IsNullOrWhiteSpace(variableFromColumnA) && !string.IsNullOrWhiteSpace(variableFromColumnB))
+                {
+                    variableFromColumnA.Should().Be(variableFromColumnB);
+                }
+            }
+        }
     }
 }

--- a/DSL.ReqnrollPlugin/DSL.ReqnrollPlugin.csproj
+++ b/DSL.ReqnrollPlugin/DSL.ReqnrollPlugin.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>DSL.ReqnrollPlugin</AssemblyName>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageId>DSL.Reqnroll</PackageId>
-		<Version>1.3.1</Version>
+		<Version>1.3.2</Version>
 		<Product>DSL Reqnroll Plugin</Product>
 		<Authors>Piotr Nowak</Authors>
 		<Company></Company>
@@ -22,11 +22,12 @@
 			-&gt; Create dynamic test data using regular expression
 			-&gt; Simple calculations via bespoke transformations
 		</Description>
-		<Copyright>Copyright © 2025 Piotr Nowak</Copyright>
+		<Copyright>Copyright © 2026 Piotr Nowak</Copyright>
 		<PackageProjectUrl>https://github.com/nowakpi/DSL.Reqnroll</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/nowakpi/DSL.Reqnroll</RepositoryUrl>
 		<PackageTags>Reqnroll DSL variables context</PackageTags>
 		<PackageReleaseNotes>
+			v1.3.2: Bug fix: Gherkin statement will be transformed correctly when repeated in the same scenario
 			v1.3.1: Bug fix: empty string are transformed into empty string instead of null
 			v1.3.0: Adding support for more complex mixes of various transformations
 			v1.2.1: Upgrading to Reqnroll 2.4.1 and xUnit 2.8.1

--- a/DSL.ReqnrollPlugin/Helpers/TransformerSequenceGenerator.cs
+++ b/DSL.ReqnrollPlugin/Helpers/TransformerSequenceGenerator.cs
@@ -22,19 +22,19 @@ namespace DSL.ReqnrollPlugin.Helpers
             return BitConverter.ToString(hashValue).Replace("-", "");
         }
 
-        private static bool WasTextAlreadyTransformed(string statementId, TransformableText transformableText, Dictionary<string, object> scenarioContext)
+        private static bool WasTextAlreadyTransformed(string statementId, TransformableText transformableText, Dictionary<string, object> transformationTracker)
         {
             string key = statementId + KEY_SEPARATOR + transformableText.StartIndex.ToString() + KEY_SEPARATOR + transformableText.EndIndex + KEY_SEPARATOR + transformableText.Text;
-            return scenarioContext.ContainsKey(key);
+            return transformationTracker.ContainsKey(key);
         }
 
-        private static void RegisterTransformedText(string statementId, TransformableText transformableText, Dictionary<string, object> scenarioContext)
+        private static void RegisterTransformedText(string statementId, TransformableText transformableText, Dictionary<string, object> transformationTracker)
         {
             string key = statementId + KEY_SEPARATOR + transformableText.StartIndex.ToString() + KEY_SEPARATOR + transformableText.EndIndex + KEY_SEPARATOR + transformableText.Text;
-            scenarioContext.Add(key, true);
+            transformationTracker.Add(key, true);
         }
 
-        public static TransformableText? GetAnyTransformableText(in string inputStatement, Dictionary<string, object> scenarioContext)
+        public static TransformableText? GetAnyTransformableText(in string inputStatement, Dictionary<string, object> transformationTracker)
         {
             if (inputStatement == null || string.IsNullOrWhiteSpace(inputStatement)) return null;
 
@@ -62,10 +62,10 @@ namespace DSL.ReqnrollPlugin.Helpers
                         TransformerId = PatternMatchConfig.GetTransformerForPrefix(lastOpenPattern)
                     };
 
-                    if (!WasTextAlreadyTransformed(statementId, textCandidate, scenarioContext))
+                    if (!WasTextAlreadyTransformed(statementId, textCandidate, transformationTracker))
                     {
                         result = textCandidate;
-                        RegisterTransformedText(statementId, textCandidate, scenarioContext);
+                        RegisterTransformedText(statementId, textCandidate, transformationTracker);
                         break;
                     }
                 }

--- a/DSL.ReqnrollPlugin/Transformers/TransformerAggregator.cs
+++ b/DSL.ReqnrollPlugin/Transformers/TransformerAggregator.cs
@@ -21,9 +21,10 @@ namespace DSL.ReqnrollPlugin.Transformers
         public string Transform(string inputString, ScenarioContext context)
         {
             if (string.IsNullOrEmpty(inputString)) { return inputString; }
-            
+
+            var transformedTracker = new Dictionary<string, object>();
             TransformableText? text;
-            while ((text = TransformerSequenceGenerator.GetAnyTransformableText(inputString, context)) != null) 
+            while ((text = TransformerSequenceGenerator.GetAnyTransformableText(inputString, transformedTracker)) != null) 
             {
                 TransformableText transformableText = (TransformableText) text;
                 var transformer = _transformers[transformableText.TransformerId];


### PR DESCRIPTION
Allowing transformation of new instances of the same statement when it appears multiple times in a single scenario.

_Background_: current algorithm keeps track of already processed (transformed) elements (substrings) of the Gherkin statement by keeping records of those in a dictionary. Scenario context was used for this purpose but since its content persists between statements same sentence used in a new line of the scenario was deemed as already processed. I changed this behavior so that transformer aggregator keeps track of already transformed elements per each statement separately. 